### PR TITLE
Add available equipments for consumption display to detail panel

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1,2 +1,3 @@
 {
+  "Available": "(Available: %d)"
 }

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1,3 +1,3 @@
 {
-  "Available": "(Available: %d)"
+  "Available": " (Available: %d)"
 }

--- a/i18n/ja-JP.json
+++ b/i18n/ja-JP.json
@@ -43,6 +43,8 @@
   "Modify": "修正",
   "Invalid": "無効",
   "Infinity": "無上限",
+  "Available": "(Available: %d)",
+  
 
   "New equipment plan": "新しい改修計画",
   "Expand only non-empty categories": "改修計画がある装備種類だけを展開",

--- a/i18n/ja-JP.json
+++ b/i18n/ja-JP.json
@@ -43,7 +43,7 @@
   "Modify": "修正",
   "Invalid": "無効",
   "Infinity": "無上限",
-  "Available": "(Available: %d)",
+  "Available": " (Available: %d)",
   
 
   "New equipment plan": "新しい改修計画",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -43,7 +43,7 @@
   "Modify": "修改",
   "Invalid": "无效",
   "Infinity": "不设上限",
-  "Available": "可用",
+  "Available": "(可用: %d)",
 
   "New equipment plan": "新建装备计划",
   "Expand only non-empty categories": "仅展开内容非空的装备类别",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -43,7 +43,7 @@
   "Modify": "修改",
   "Invalid": "无效",
   "Infinity": "不设上限",
-  "Available": "(可用: %d)",
+  "Available": " (可用: %d)",
 
   "New equipment plan": "新建装备计划",
   "Expand only non-empty categories": "仅展开内容非空的装备类别",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -43,6 +43,7 @@
   "Modify": "修改",
   "Invalid": "无效",
   "Infinity": "不设上限",
+  "Available": "可用",
 
   "New equipment plan": "新建装备计划",
   "Expand only non-empty categories": "仅展开内容非空的装备类别",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -43,7 +43,7 @@
   "Modify": "修改",
   "Invalid": "無效",
   "Infinity": "不設上限",
-  "Available": "(可用: %d)",
+  "Available": " (可用: %d)",
 
   "New equipment plan": "新建裝備計劃",
   "Expand only non-empty categories": "僅展開內容非空的裝備類別",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -43,7 +43,7 @@
   "Modify": "修改",
   "Invalid": "無效",
   "Infinity": "不設上限",
-  "Available": "可用",
+  "Available": "(可用: %d)",
 
   "New equipment plan": "新建裝備計劃",
   "Expand only non-empty categories": "僅展開內容非空的裝備類別",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -43,6 +43,7 @@
   "Modify": "修改",
   "Invalid": "無效",
   "Infinity": "不設上限",
+  "Available": "可用",
 
   "New equipment plan": "新建裝備計劃",
   "Expand only non-empty categories": "僅展開內容非空的裝備類別",

--- a/views/detail-row.es
+++ b/views/detail-row.es
@@ -10,14 +10,16 @@ import { MatRow } from './mat-row'
 import {
   adjustedRemodelChainsSelector,
   shipUniqueMapSelector,
+  equipAvailableSelector,
 } from './selectors'
 
 const { __ } = window.i18n['poi-plugin-item-improvement']
 
-const parseItem = ($equips, $useitems, item, count) => {
+const parseItem = ($equips, $useitems, item, count, available) => {
+  console.log('availableitem',available[item])
   if (_.isString(item)) {
     const icon = parseInt(item.replace(/\D/g, ''), 10)
-
+    console.log('itemstring', item)
     return {
       icon,
       name: _.get($useitems, [icon, 'api_name']),
@@ -34,6 +36,7 @@ const parseItem = ($equips, $useitems, item, count) => {
       count,
       id: item,
       type: 'item',
+      available: available[item] ? available[item].length : 0,
     }
   }
 
@@ -43,6 +46,7 @@ const parseItem = ($equips, $useitems, item, count) => {
     count: 0,
     id: 0,
     type: 'item',
+    available: 0,
   }
 }
 
@@ -52,8 +56,9 @@ const DetailRow = connect(state =>
     $const: constSelector(state) || {},
     chains: adjustedRemodelChainsSelector(state),
     uniqMap: shipUniqueMapSelector(state),
+    available: equipAvailableSelector(state),
   })
-)(({ row, day, $const: { $ships, $equips, $useitems }, chains, uniqMap }) => {
+)(({ row, day, $const: { $ships, $equips, $useitems }, chains, uniqMap, available }) => {
   const result = []
   row.improvement.forEach(({ req, resource, upgrade }) => {
     const assistants = _(req)
@@ -106,9 +111,9 @@ const DetailRow = connect(state =>
       let items = []
 
       if (_.isArray(extra)) {
-        items = extra.map(([item, _count]) => parseItem($equips, $useitems, item, _count))
+        items = extra.map(([item, _count]) => parseItem($equips, $useitems, item, _count, available))
       } else {
-        items = [parseItem($equips, $useitems, extra, count)]
+        items = [parseItem($equips, $useitems, extra, count, available)]
       }
 
       result.push(
@@ -126,7 +131,6 @@ const DetailRow = connect(state =>
     })
   })
   const [fuel, ammo, steel, bauxite] = row.improvement[0].resource[0]
-
 
   return (
     <div>

--- a/views/detail-row.es
+++ b/views/detail-row.es
@@ -16,10 +16,8 @@ import {
 const { __ } = window.i18n['poi-plugin-item-improvement']
 
 const parseItem = ($equips, $useitems, item, count, available) => {
-  console.log('availableitem',available[item])
   if (_.isString(item)) {
     const icon = parseInt(item.replace(/\D/g, ''), 10)
-    console.log('itemstring', item)
     return {
       icon,
       name: _.get($useitems, [icon, 'api_name']),

--- a/views/mat-row.es
+++ b/views/mat-row.es
@@ -103,7 +103,8 @@ const MatRow = ({ stage, day, assistants, upgrade, items, development, improveme
               <ItemIcon
                 item={item}
               />
-              {__r(item.name)}{typeof item.available === 'number' ? ' ('+ __("Available") + ":  "+item.available+')' : null}
+              {__r(item.name)}{typeof item.available === 'number' &&
+__('Available', item.available)}
               </div>
             ))
           }

--- a/views/mat-row.es
+++ b/views/mat-row.es
@@ -103,7 +103,7 @@ const MatRow = ({ stage, day, assistants, upgrade, items, development, improveme
               <ItemIcon
                 item={item}
               />
-                {__r(item.name)}
+              {__r(item.name)}{typeof item.available === 'number' ? ' ('+ __("Available") + ":  "+item.available+')' : null}
               </div>
             ))
           }

--- a/views/selectors.es
+++ b/views/selectors.es
@@ -86,7 +86,7 @@ export const equipAvailableSelector = createSelector(
   [
     equipsSelector,
   ], equips => _(equips)
-    .filter({'api_locked': 0, 'api_level': 0})
+    .filter({'api_level': 0})
     .groupBy('api_slotitem_id')
     .value()
 )

--- a/views/selectors.es
+++ b/views/selectors.es
@@ -82,6 +82,14 @@ export const starCraftPlanSelector = createSelector(
     configSelector,
   ], config => _.get(config, 'plugin.poi-plugin-starcraft.plans', {})
 )
+export const equipAvailableSelector = createSelector(
+  [
+    equipsSelector,
+  ], equips => _(equips)
+    .filter({'api_locked': 0, 'api_level': 0})
+    .groupBy('api_slotitem_id')
+    .value()
+)
 
 export const equipLevelStatSelector = createSelector(
   [


### PR DESCRIPTION
This resolves #31, resolves poooi/poi#1549

Available equipments includes the ones that is:

- <del>unlocked</del>
- without improvement

Limitation:

- The available number of items which are not equipments, like gum-mounts, aerial armaments and engines, can't be displayed.

To do:

- JP i18n
